### PR TITLE
Simplify multiple zeek version support

### DIFF
--- a/scripts/detect.zeek
+++ b/scripts/detect.zeek
@@ -8,50 +8,26 @@ export {
   redef enum Notice::Type += { Pingback_Tunnel }; 
 }
 
-# This @if directive is required to pivot on the version of Zeek 
-# where the icmp_conn record type was deprecated in favour of icmp_info
-# See https://github.com/zeek/zeek/blob/master/CHANGES#L3140
-@if ( Version::info$version_number >= 30200 )
-    event icmp_echo_reply(c: connection, info: icmp_info, id: count, seq: count, payload: string) {
-        if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
-        {
-            NOTICE([$note=Pingback::Pingback_Tunnel,
-                $conn=c,
-                $identifier=cat(c$id$resp_h),
-                $msg=fmt("An ICMP ping reply message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/"),
-                $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
-        }
+# 'any' is used here for info because this could be an icmp_info or icmp_conn
+# depending on the zeek version. since it is only used in a fmt("%s") statement
+# the specific type is not important.
+event icmp_echo_reply(c: connection, info: any, id: count, seq: count, payload: string) {
+    if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
+    {
+        NOTICE([$note=Pingback::Pingback_Tunnel,
+            $conn=c,
+            $identifier=cat(c$id$resp_h),
+            $msg=fmt("An ICMP ping reply message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/"),
+            $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
     }
-    event icmp_echo_request(c: connection, info: icmp_info, id: count, seq: count, payload: string) {
-        if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
-        {
-            NOTICE([$note=Pingback::Pingback_Tunnel,
-                $conn=c,
-                $identifier=cat(c$id$orig_h),
-                $msg=fmt("An ICMP ping request message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/" ),
-                $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
-        }
+}
+event icmp_echo_request(c: connection, info: any, id: count, seq: count, payload: string) {
+    if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
+    {
+        NOTICE([$note=Pingback::Pingback_Tunnel,
+            $conn=c,
+            $identifier=cat(c$id$orig_h),
+            $msg=fmt("An ICMP ping request message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/" ),
+            $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
     }
-
-@else
-    event icmp_echo_request(c: connection, info: icmp_conn, id: count, seq: count, payload: string) {
-        if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
-        {
-            NOTICE([$note=Pingback::Pingback_Tunnel,
-                $conn=c,
-                $identifier=cat(c$id$orig_h),
-                $msg=fmt("An ICMP ping request message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/" ),
-                $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
-        }
-    }
-    event icmp_echo_reply(c: connection, info: icmp_conn, id: count, seq: count, payload: string) {
-        if ( seq in Pingback::message_types && |payload| in Pingback::payload_lengths && Pingback::commands in payload ) 
-        {
-            NOTICE([$note=Pingback::Pingback_Tunnel,
-                $conn=c,
-                $identifier=cat(c$id$resp_h),
-                $msg=fmt("An ICMP ping reply message may have been Pingback C2 ref:trustwave.com/en-us/resources/blogs/spiderlabs-blog/backdoor-at-the-end-of-the-icmp-tunnel/"),
-                $sub=fmt("seq=%s , |payload|=%s , icmp_info=%s , first 20 bytes of ICMP payload=%s",seq,|payload|,info,sub_bytes(payload,0,20))]);
-        }
-    }
-@endif
+}


### PR DESCRIPTION
Since the info record is only used in a fmt("%s") statement the specific
type is not important and 'any' can be used.